### PR TITLE
Updated troubleshooting-faq.Rmd

### DIFF
--- a/vignettes/troubleshooting-faq.Rmd
+++ b/vignettes/troubleshooting-faq.Rmd
@@ -44,4 +44,26 @@ chunk name to `example1` or `example_` as long as it does not change the meaning
 or make it hard for someone to understand the code. If you do not understand the
 code or document well, always ask the maintainer or reviewers for what to do.
 
+### *Question:* Having problem while checking `R CMD build` contains the `HTML`?
+*Background info*: While converting a Sweave vignette to R markdown vignette sometimes
+ we face problem while doing R CMD check using 
+ `tar ztf package_name.tar.gz | grep 'doc/vignette_name'` even after the R CMD build
+ runs succesfully without any errors or timeouts this could happen if we missed some important lines 
+ in YAML header.
 
+ *Answer*: Look for the file which is actually problematic try to run 
+ `tar ztf package_name.tar.gz | grep doc` in your package terminal if it still
+ does not build the PDF or the html file try removing your `.Rmd` file and add
+ `.Rnw` file if it build the PDF that means you have problem in your .Rmd file
+ one of the possible solution of the problem might be that your
+ `%\VignetteEngine{knitr::rmarkdown}` line is missing in the YAML header, you can try to add 
+ `%\VignetteEngine{knitr::rmarkdown}` line in YAML header
+ and again run `R CMD build` and `R CMD check` this happens because the YAML header plays very
+ important role in the conversion
+ process, The first few lines of the vignette contain important 
+ [metadata](https://r-pkgs.org/vignettes.html#metadata)
+ you can refer for more information regarding YAML header. If you do not understand the 
+ code or [contubute](https://bioconductor.github.io/sweave2rmd/articles/contribute.html) 
+ document well, always ask the maintainer or reviewers for what to do.
+ 
+ 

--- a/vignettes/troubleshooting-faq.Rmd
+++ b/vignettes/troubleshooting-faq.Rmd
@@ -46,23 +46,21 @@ code or document well, always ask the maintainer or reviewers for what to do.
 
 ### *Question:* Are you having trouble checking if `R CMD build` includes the `HTML`?
 *Background info*: Sometimes, when converting a Sweave vignette to an R Markdown vignette,
-we may encounter issues while running `R CMD check` using the command `tar ztf
+we may encounter issues while running `R CMD build` using the command `tar ztf
 package_name.tar.gz | grep 'doc/vignette_name'`, even if the `R CMD build`
 command completes successfully without any errors or timeouts. This can happen
-if we have missed some essential lines in the YAML header. To ensure a smooth
-conversion process, it is crucial to include all the necessary information in
-the YAML header.
+if we have missed some essential lines in the YAML header or DESCRIPTION file.
 
-*Answer*:To identify the problematic file, run `tar ztf package_name.tar.gz | grep doc`
-in your package terminal. If running the above command does not build the PDF or
-HTML file, try removing your `.Rmd` file and adding a `.Rnw` file, if building
-the PDF with the .Rnw file is successful, it indicates a problem with the `.Rmd`
-file. One possible solution to the problem could be adding
-`%\VignetteEngine{knitr::rmarkdown}` in the YAML header. The YAML header is
-crucial to the conversion process, and the first few lines of the vignette
-contain important metadata, refer to this
-[article](https://r-pkgs.org/vignettes.html#metadata) for more information
-regarding the YAML header. If you are unsure about the code or document, always
-ask the maintainer or reviewers for guidance.
+*Answer*: To identify the problematic file, run `tar ztf package_name.tar.gz | grep doc`
+in your package terminal. If running the above command does not build the HTML
+file, try troubleshooting by removing your `.Rmd` file then running `R CMD
+build` and grepping the tarball for other vignettes. If other vignettes are
+built, the problem could be your .Rmd file. There are a couple of possible
+issues that could cause this problem. One possible issue might be that the
+`%\VignetteEngine{knitr::rmarkdown}` is missing from the YAML header. Another
+possible issue could be that `VignetteBuilder: knitr` is missing from the
+DESCRIPTION file. You can solve these issues by adding the missing lines in the
+correct format in their respective files. If you are unsure about the code or
+document, always ask the maintainer or reviewers for guidance.
  
  

--- a/vignettes/troubleshooting-faq.Rmd
+++ b/vignettes/troubleshooting-faq.Rmd
@@ -46,19 +46,21 @@ code or document well, always ask the maintainer or reviewers for what to do.
 
 ### *Question:* Are you having trouble checking if `R CMD build` includes the `HTML`?
 *Background info*: Sometimes, when converting a Sweave vignette to an R Markdown vignette,
-we may encounter issues while running `R CMD check` using the command
-`tar ztf package_name.tar.gz | grep 'doc/vignette_name'`, even if the `R CMD build`
-command completes successfully without any errors or timeouts. This can happen if we
-have missed some essential lines in the YAML header. To ensure a smooth conversion process,
-it is crucial to include all the necessary information in the YAML header.
+we may encounter issues while running `R CMD check` using the command `tar ztf
+package_name.tar.gz | grep 'doc/vignette_name'`, even if the `R CMD build`
+command completes successfully without any errors or timeouts. This can happen
+if we have missed some essential lines in the YAML header. To ensure a smooth
+conversion process, it is crucial to include all the necessary information in
+the YAML header.
 
-*Answer*: To identify the problematic file, run `tar ztf package_name.tar.gz | grep doc`
-in your package terminal. If running the above command does not build the PDF or HTML file, try removing
-your `.Rmd` file and adding a `.Rnw` file, if building the PDF with the .Rnw
-file is successful, it indicates a problem with the `.Rmd` file. One possible
-solution to the problem could be adding `%\VignetteEngine{knitr::rmarkdown}` in
-the YAML header. The YAML header is crucial to the conversion process, and the
-first few lines of the vignette contain important metadata, refer to this
+*Answer*:To identify the problematic file, run `tar ztf package_name.tar.gz | grep doc`
+in your package terminal. If running the above command does not build the PDF or
+HTML file, try removing your `.Rmd` file and adding a `.Rnw` file, if building
+the PDF with the .Rnw file is successful, it indicates a problem with the `.Rmd`
+file. One possible solution to the problem could be adding
+`%\VignetteEngine{knitr::rmarkdown}` in the YAML header. The YAML header is
+crucial to the conversion process, and the first few lines of the vignette
+contain important metadata, refer to this
 [article](https://r-pkgs.org/vignettes.html#metadata) for more information
 regarding the YAML header. If you are unsure about the code or document, always
 ask the maintainer or reviewers for guidance.

--- a/vignettes/troubleshooting-faq.Rmd
+++ b/vignettes/troubleshooting-faq.Rmd
@@ -44,26 +44,23 @@ chunk name to `example1` or `example_` as long as it does not change the meaning
 or make it hard for someone to understand the code. If you do not understand the
 code or document well, always ask the maintainer or reviewers for what to do.
 
-### *Question:* Having problem while checking `R CMD build` contains the `HTML`?
-*Background info*: While converting a Sweave vignette to R markdown vignette sometimes
- we face problem while doing R CMD check using 
- `tar ztf package_name.tar.gz | grep 'doc/vignette_name'` even after the R CMD build
- runs succesfully without any errors or timeouts this could happen if we missed some important lines 
- in YAML header.
+### *Question:* Are you having trouble checking if `R CMD build` includes the `HTML`?
+*Background info*: Sometimes, when converting a Sweave vignette to an R Markdown vignette,
+we may encounter issues while running `R CMD check` using the command
+`tar ztf package_name.tar.gz | grep 'doc/vignette_name'`, even if the `R CMD build`
+command completes successfully without any errors or timeouts. This can happen if we
+have missed some essential lines in the YAML header. To ensure a smooth conversion process,
+it is crucial to include all the necessary information in the YAML header.
 
- *Answer*: Look for the file which is actually problematic try to run 
- `tar ztf package_name.tar.gz | grep doc` in your package terminal if it still
- does not build the PDF or the html file try removing your `.Rmd` file and add
- `.Rnw` file if it build the PDF that means you have problem in your .Rmd file
- one of the possible solution of the problem might be that your
- `%\VignetteEngine{knitr::rmarkdown}` line is missing in the YAML header, you can try to add 
- `%\VignetteEngine{knitr::rmarkdown}` line in YAML header
- and again run `R CMD build` and `R CMD check` this happens because the YAML header plays very
- important role in the conversion
- process, The first few lines of the vignette contain important 
- [metadata](https://r-pkgs.org/vignettes.html#metadata)
- you can refer for more information regarding YAML header. If you do not understand the 
- code or [contubute](https://bioconductor.github.io/sweave2rmd/articles/contribute.html) 
- document well, always ask the maintainer or reviewers for what to do.
+*Answer*: To identify the problematic file, run `tar ztf package_name.tar.gz | grep doc`
+in your package terminal. If running the above command does not build the PDF or HTML file, try removing
+your `.Rmd` file and adding a `.Rnw` file, if building the PDF with the .Rnw
+file is successful, it indicates a problem with the `.Rmd` file. One possible
+solution to the problem could be adding `%\VignetteEngine{knitr::rmarkdown}` in
+the YAML header. The YAML header is crucial to the conversion process, and the
+first few lines of the vignette contain important metadata, refer to this
+[article](https://r-pkgs.org/vignettes.html#metadata) for more information
+regarding the YAML header. If you are unsure about the code or document, always
+ask the maintainer or reviewers for guidance.
  
  


### PR DESCRIPTION
 I have included a Q&A documentation block that addresses a common issue encountered during the R CMD check process, even when the R CMD build process runs smoothly without any errors or timeouts. The problem is often caused by the absence of the "%\VignetteEngine{knitr::rmarkdown}" line, which can be a valuable reference for contributors.